### PR TITLE
feat: creating the simple_workflow module

### DIFF
--- a/modules/simple_workflow/Readme.MD
+++ b/modules/simple_workflow/Readme.MD
@@ -1,0 +1,37 @@
+# terraform-google-cloud-workflow
+This module is used to create a [Workflow](https://cloud.google.com/workflows/docs) without any triggers.
+
+- Creates a Workflow
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project | `string` | n/a | yes |
+| region | The region where the workflow will be deployed | `string` | n/a | yes |
+| service\_account\_id | The ID of the service account to associate with the workflow | `string` | n/a | yes |
+| workflow\_name | The name of the workflow | `string` | n/a | yes |
+| description | The description of the workflow | `string` | `"A simple workflow"` | no |
+| workflow\_call\_log\_level | The log level for workflow calls | `string` | `"LOG_ERRORS_ONLY"` | no |
+| workflow\_labels | Labels to apply to the workflow | `map(string)` | `{}` | no |
+| workflow\_user\_env\_vars | User-defined environment variables for the workflow | `map(string)` | `{}` | no |
+| workflow\_source | The source code of the workflow | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| workflow\_id | Workflow identifier for the resource with format projects/{{project}}/locations/{{region}}/workflows/{{name}} |
+
+
+## Requirements
+
+These sections describe requirements for using this module.
+
+### Software
+
+The following dependencies must be available:
+
+- [Terraform][terraform] v1.3
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v5.7
+

--- a/modules/simple_workflow/main.tf
+++ b/modules/simple_workflow/main.tf
@@ -1,0 +1,11 @@
+resource "google_workflows_workflow" "example" {
+  project         = var.project_id
+  name            = var.workflow_name
+  region          = var.region
+  description     = var.description
+  service_account = var.service_account_id
+  call_log_level  = var.workflow_call_log_level
+  labels          = var.workflow_labels
+  user_env_vars   = var.workflow_user_env_vars
+  source_contents = var.workflow_source
+}

--- a/modules/simple_workflow/outputs.tf
+++ b/modules/simple_workflow/outputs.tf
@@ -1,0 +1,4 @@
+output "workflow_id" {
+  value       = google_workflows_workflow.example.id
+  description = "Workflow identifier for the resource with format projects/{{project}}/locations/{{region}}/workflows/{{name}}"
+}

--- a/modules/simple_workflow/variables.tf
+++ b/modules/simple_workflow/variables.tf
@@ -1,0 +1,48 @@
+variable "project_id" {
+  description = "The ID of the project"
+  type        = string
+}
+
+variable "workflow_name" {
+  description = "The name of the workflow"
+  type        = string
+}
+
+variable "region" {
+  description = "The region where the workflow will be deployed"
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the workflow"
+  type        = string
+  default     = "A simple workflow"
+}
+
+variable "service_account_id" {
+  description = "The ID of the service account to associate with the workflow"
+  type        = string
+}
+
+variable "workflow_call_log_level" {
+  description = "The log level for workflow calls"
+  type        = string
+  default     = "LOG_ERRORS_ONLY"
+}
+
+variable "workflow_labels" {
+  description = "Labels to apply to the workflow"
+  type        = map(string)
+  default     = {}
+}
+
+variable "workflow_user_env_vars" {
+  description = "User-defined environment variables for the workflow"
+  type        = map(string)
+  default     = {}
+}
+
+variable "workflow_source" {
+  description = "The source code of the workflow"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,7 @@ variable "workflow_trigger" {
     )
     error_message = "Either cloud_scheduler OR event_arc information is supported."
   }
+  default = null
 }
 
 variable "service_account_email" {

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,6 @@ variable "workflow_trigger" {
     )
     error_message = "Either cloud_scheduler OR event_arc information is supported."
   }
-  default = null
 }
 
 variable "service_account_email" {


### PR DESCRIPTION
As per requirement on the https://gr4vy.atlassian.net/browse/PE-797, the workflow will not contain a trigger like a cron job or an eventarc. This workflow will be created and invoked by a core-api job. 

Since this module needs a trigger to create the workflow and we can reuse this in the future I've added a simple_workflow module.