### PR TITLE
feat: allow workflow trigger location to be independently set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "google_eventarc_trigger" "workflow" {
   count           = local.enable_eventarc
   project         = var.project_id
   name            = var.workflow_trigger.event_arc.name
-  location        = var.region
+  location        = var.workflow_trigger.event_arc.region
   service_account = var.workflow_trigger.event_arc.service_account_email
 
   dynamic "matching_criteria" {
@@ -76,7 +76,7 @@ resource "google_cloud_scheduler_job" "workflow" {
   schedule         = var.workflow_trigger.cloud_scheduler.cron
   time_zone        = var.workflow_trigger.cloud_scheduler.time_zone
   attempt_deadline = var.workflow_trigger.cloud_scheduler.deadline
-  region           = var.region
+  region           = var.workflow_trigger.cloud_scheduler.region
 
   http_target {
     http_method = "POST"

--- a/variables.tf
+++ b/variables.tf
@@ -61,10 +61,12 @@ variable "workflow_trigger" {
       deadline              = string
       argument              = optional(string)
       service_account_email = string
+      region                = string
     }))
     event_arc = optional(object({
       name                  = string
       service_account_email = string
+      region                = string
       matching_criteria = set(object({
         attribute = string
         operator  = optional(string)


### PR DESCRIPTION
Google Cloud Scheduler is not available in all of the regions that Workflows are available in.

This change allows the Cloud Schedule to be created in a different region from the Workflow.