### PR TITLE
feat: upgrading tf version / enabling deletion protection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "random_string" "string" {
 module "service_account" {
   count         = var.service_account_create ? 1 : 0
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.2.3"
+  version       = "~> 4.5.3"
   project_id    = var.project_id
   prefix        = "wf-${random_string.string[0].result}"
   names         = ["simple"]
@@ -116,14 +116,15 @@ module "service_account" {
 }
 
 resource "google_workflows_workflow" "workflow" {
-  name            = var.workflow_name
-  region          = var.region
-  description     = var.workflow_description
-  service_account = local.service_account_email
-  project         = var.project_id
-  labels          = var.workflow_labels
-  source_contents = var.workflow_source
-  user_env_vars   = var.workflow_user_env_vars 
+  name                = var.workflow_name
+  region              = var.region
+  description         = var.workflow_description
+  service_account     = local.service_account_email
+  project             = var.project_id
+  labels              = var.workflow_labels
+  source_contents     = var.workflow_source
+  user_env_vars       = var.workflow_user_env_vars
+  deletion_protection = var.deletion_protection
 
   lifecycle {
     ignore_changes = [

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,9 @@ variable "service_account_create" {
   type        = bool
   default     = false
 }
+
+variable "deletion_protection" {
+  description = "Whether the workflow has deletion protection."
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.7.0, <= 6.0.0"
+      version = "~> 6.28.0"
     }
 
     random = {


### PR DESCRIPTION
Changes include updating the version constraints for the `google` provider to the latest, adding a new variable for deletion protection to be used in terraform-gcp, and updating the version of the `service-accounts` module to latest.