### PR TITLE
chore: extending lifecycle ignore changes to simple_workflow

### DIFF
--- a/modules/simple_workflow/main.tf
+++ b/modules/simple_workflow/main.tf
@@ -9,4 +9,10 @@ resource "google_workflows_workflow" "example" {
   user_env_vars       = var.workflow_user_env_vars
   source_contents     = var.workflow_source
   deletion_protection = var.deletion_protection
+
+  lifecycle {
+    ignore_changes = [
+      user_env_vars
+    ]
+  }
 }


### PR DESCRIPTION
This pull request adds a lifecycle ignore changes block to the `google_workflows_workflow` resource in the Terraform module to ignore changes to the `user_env_vars`.